### PR TITLE
Issue #13: Fix IE8 click handler for VML

### DIFF
--- a/jqvmap/jquery.vmap.js
+++ b/jqvmap/jquery.vmap.js
@@ -237,13 +237,20 @@
         node.setFill = function (color)
         {
           this.getElementsByTagName('fill')[0].color = color;
+          if(this.getAttribute("original") === null)
+          {
+            this.setAttribute("original", color);
+          }
         };
 
         node.getFill = function (color)
         {
           return this.getElementsByTagName('fill')[0].color;
         };
-
+        node.getOriginalFill = function ()
+        {
+          return this.getAttribute("original");
+        };
         node.setOpacity = function (opacity)
         {
           this.getElementsByTagName('fill')[0].opacity = parseInt(opacity * 100, 10) + '%';


### PR DESCRIPTION
setFill and getOriginalFill methods were different / not implemented for svg and vml. Fix this, now IE8 doesn't throw `Object doesn't support this property or method` onRegionClick.
