### PR TITLE
Add methods for highlighting and selecting areas programmatically

### DIFF
--- a/jqvmap/jquery.vmap.js
+++ b/jqvmap/jquery.vmap.js
@@ -30,7 +30,9 @@
     onLabelShow: 'labelShow',
     onRegionOver: 'regionMouseOver',
     onRegionOut: 'regionMouseOut',
-    onRegionClick: 'regionClick'
+    onRegionClick: 'regionClick',
+    onRegionSelect: 'regionSelect',
+    onRegionDeselect: 'regionDeselect'
   };
 
   $.fn.vectorMap = function (options) {
@@ -615,22 +617,32 @@
 
     select: function (cc, path) {
       path = path || $('#' + this.getCountryId(cc))[0];
-      if (this.multiSelectRegion && this.selectedRegions.indexOf(cc) < 0) {
-        this.selectedRegions.push(cc);
-      } else {
-        this.selectedRegions = [cc];
-      }
-      if (this.selectedColor) {
-        path.currentFillColor = this.selectedColor;
-        path.setFill(this.selectedColor);
+      if(this.selectedRegions.indexOf(cc) < 0) {
+        if (this.multiSelectRegion) {
+          this.selectedRegions.push(cc);
+        } else {
+          this.selectedRegions = [cc];
+        }
+        // MUST BE after the change of selectedRegions
+        // Otherwise, we might loop
+        $(this.container).trigger('regionSelect.jqvmap', [cc]);
+        if (this.selectedColor) {
+          path.currentFillColor = this.selectedColor;
+          path.setFill(this.selectedColor);
+        }
       }
     },
 
     deselect: function (cc, path) {
       path = path || $('#' + this.getCountryId(cc))[0];
-      this.selectedRegions.splice(this.selectedRegions.indexOf(cc), 1);
-      path.currentFillColor = path.getOriginalFill();
-      path.setFill(path.getOriginalFill());
+      if(this.selectedRegions.indexOf(cc) >= 0) {
+        this.selectedRegions.splice(this.selectedRegions.indexOf(cc), 1);
+        // MUST BE after the change of selectedRegions
+        // Otherwise, we might loop
+        $(this.container).trigger('regionDeselect.jqvmap', [cc]);
+        path.currentFillColor = path.getOriginalFill();
+        path.setFill(path.getOriginalFill());
+      }
     },
 
     isSelected: function(cc) {


### PR DESCRIPTION
This adds a few methods that allow code to select or highlight areas, instead of just via mouse input. This has required some extensive internal changes to realise, but there doesn't seem to be any issues as of now.

```
$('#mymap').vectorMap('select', 'us'); // selects the United States
$('#mymap').vectorMap('deselect', 'us'); // deselects the United States
$('#mymap').vectorMap('highlight', 'us'); // highlights ("hovers over") the United States
$('#mymap').vectorMap('unhighlight', 'us'); // unhighlights ("mouseouts") the United States
```

My use-case for this change is that I want to have a list of important countries beside the map, and when a list entry is selected or hovered, the relevant map country should reflect the change.

It is now also possible to call any map method directly via e.g. `$('#mymap').vectorMap('setColors', 'us', '#000');`. It made the most sense to expose the new APIs like this.

The first commit is format fixes that Emacs did automatically when I loaded the file (e.g. converting tabs to spaces for indentation etc.). I would recommend that this commit is included, but it is of course possible to cherry-pick it out if you prefer inconsistent indentation.
