### PR TITLE
Don't allow the tooltip to be positioned outside the map's bounds

### DIFF
--- a/jqvmap/jquery.vmap.js
+++ b/jqvmap/jquery.vmap.js
@@ -478,9 +478,17 @@
     if (params.showTooltip) {
       params.container.mousemove(function (e) {
         if (map.label.is(':visible')) {
-          map.label.css({
-            left: e.pageX - 15 - map.labelWidth,
-            top: e.pageY - 15 - map.labelHeight
+            var left = e.pageX - 15 - map.labelWidth;
+            var top = e.pageY - 15 - map.labelHeight;
+            
+            if(left < 0)
+               left = e.pageX + 15;
+            if(top < 0)
+                top = e.pageY + 15;
+            
+            map.label.css({
+                left: left,
+                top: top
           });
         }
       });


### PR DESCRIPTION
It's undesirable (at least for us) to have the tooltip appear outside of the bounds of the map, which causes the tooltip to be partially hidden if the map is in an iframe. This patch prevents that by moving the tooltip to the right (or below) the mouse position if its left or top side would otherwise have a negative coordinate.
