### PR TITLE
Added touch detection function and sample code

### DIFF
--- a/jqvmap/touch_detect.js
+++ b/jqvmap/touch_detect.js
@@ -1,0 +1,4 @@
+function touch_detect() 
+{
+    return 'ontouchstart' in window || 'onmsgesturechange' in window || navigator.msMaxTouchPoints > 0;
+};

--- a/samples/touch_detect.html
+++ b/samples/touch_detect.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="UTF-8">
+    <title>JQVMap - Europe Map</title>
+
+    <link href="../jqvmap/jqvmap.css" media="screen" rel="stylesheet" type="text/css">
+    
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.2/jquery.min.js" type="text/javascript"></script>
+    <script src="../jqvmap/jquery.vmap.js" type="text/javascript"></script>
+    <script src="../jqvmap/touch_detect.js" type="text/javascript"></script>
+    <script src="../jqvmap/maps/jquery.vmap.europe.js" type="text/javascript"></script>
+
+    <script type="text/javascript">
+    jQuery(document).ready(function() {
+        jQuery('#vmap').vectorMap({
+            map: 'europe_en',
+            enableZoom: false,
+            showTooltip: false,
+            onRegionClick: function(element, code, region)
+            {
+                if ( !touch_detect() )
+                { 
+                    // we're not on a mobile device, handle the click
+                    var message = 'You clicked "' + region + '" which has the code: ' + code.toUpperCase();
+                    alert(message);
+                }
+            },
+            onRegionOver: function(element, code, region)
+            {
+                if ( touch_detect() )
+                { 
+                    /// we're not on a mobile device, handle the click
+                    var message = 'You clicked "' + region + '" which has the code: ' + code.toUpperCase();
+                    alert(message);
+                }
+            }
+        });
+    });
+    </script>
+</head>
+
+<body>
+
+    <div id="vmap" style="width: 680px; height: 520px;"></div>
+
+</body>
+</html>


### PR DESCRIPTION
On touch devices the hover functions naturally don't work and users normally need to "double-tap" map regions to activate the response. This commit adds a very small function to detect touch devices and one sample file that shows some basic usage, basically turning the onRegionHover into a click on touch devices, and only executing the real onRegionClick event on non-touch devices.

This is a "quick fix" to assist users in integrating jqvmap on touch-enabled devices without having to change any core code or files.