### PR TITLE
Fix reset.

### DIFF
--- a/jqvmap/jquery.vmap.js
+++ b/jqvmap/jquery.vmap.js
@@ -685,9 +685,8 @@
     },
 
     reset: function () {
-      this.countryTitle.reset();
       for (var key in this.countries) {
-        this.countries[key].setFill(WorldMap.defaultColor);
+        this.countries[key].setFill(this.color);
       }
       this.scale = this.baseScale;
       this.transX = this.baseTransX;


### PR DESCRIPTION
`reset` was calling reset on a non-existing property, `countryTitle`, and
then try to set the colour of all countries to `WorldMap.defaultColor`,
which is never set; instead, `this.color` should be used.

To use reset:

```
jQuery('#vmap').vectorMap('reset');
```