### PR TITLE
Default code example throws error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ jQuery('#vmap').vectorMap(
     normalizeFunction: 'linear',
     scaleColors: ['#b6d6ff', '#005ace'],
     selectedColor: '#c9dfaf',
-    selectedRegions: [],
+    selectedRegions: null,
     showTooltip: true,
     onRegionClick: function(element, code, region)
     {


### PR DESCRIPTION
Set selectedRegions to null in example. An empty array triggers string errors in line 253 of jquery.vmap.js