### PR TITLE
Add a setColor function to JQVMap

### DIFF
--- a/src/Base.js
+++ b/src/Base.js
@@ -1,6 +1,7 @@
 (function(){
 
   var apiParams = {
+    color: 1,
     colors: 1,
     values: 1,
     backgroundColor: 1,

--- a/src/JQVMap/setColor.js
+++ b/src/JQVMap/setColor.js
@@ -1,0 +1,6 @@
+JQVMap.prototype.setColor = function (color) {
+  for (var code in this.countries) {
+    this.countries[code].setFill(color);
+    this.countries[code].setAttribute('original', color);
+  }
+};


### PR DESCRIPTION
#### What does this PR do ?

This PR add a "setColor" function that can be used to color all the region on a JQVMap.

#### How should this be tested ?

You can use it this way : 
`$('#vmap').vectorMap('set', 'color',  '#77BC55');`

#### What are the relevant issues ?

I did not found any issue about this.

#### This Pull Request includes:

- [ ] Bug Fix with passing `npm test`
- [x] New Feature with passing `npm test`
- [ ] Code Improvement with passing `npm test`
- [ ] Updated Documentation
- [ ] New Map File & Example HTML

#### What gif best describes how you feel about this work ?

![wow](https://cloud.githubusercontent.com/assets/12743770/19962178/c4468692-a1b6-11e6-9885-be6869509611.gif)


