### PR TITLE
Update zoomCurStep in reset function which is currently not updated; …

### DIFF
--- a/dist/jquery.vmap.js
+++ b/dist/jquery.vmap.js
@@ -885,6 +885,7 @@ JQVMap.prototype.reset = function () {
   this.transX = this.baseTransX;
   this.transY = this.baseTransY;
   this.applyTransform();
+  this.zoomCurStep = 1;
 };
 
 JQVMap.prototype.resize = function () {


### PR DESCRIPTION
…it leads to zoom in function not working after reset function executed.

#### What does this PR do ?

This PR updates zoomCurStep in reset function. 

#### How should this be tested ?

_type_response_here_

#### What are the relevant issues ?

The issue is, after executing reset function zoom in function is not zooming in the map because zoomCurStep is not updated correctly. 

Scenario: Zoom in the map to maximum level then execute the reset function, then zoom in the map and observe the bug. 

#### This Pull Request includes:

- [ x ] Bug Fix with passing `npm test`
- [ ] New Feature with passing `npm test`
- [ ] Code Improvement with passing `npm test`
- [ ] Updated Documentation
- [ ] New Map File & Example HTML

#### What gif best describes how you feel about this work ?

https://media.giphy.com/media/xT1Ra6x2dfXyJwkB2M/giphy.gif
