### PR TITLE
docs: Fix simple typo, suffixies -> suffixes

### DIFF
--- a/tests/qunit/qunit.js
+++ b/tests/qunit/qunit.js
@@ -2963,7 +2963,7 @@ QUnit.diff = (function() {
                 textInsert = textInsert.substring(commonlength);
                 textDelete = textDelete.substring(commonlength);
               }
-              // Factor out any common suffixies.
+              // Factor out any common suffixes.
               commonlength = this.diffCommonSuffix(textInsert, textDelete);
               if (commonlength !== 0) {
                 diffs[pointer][1] = textInsert.substring(textInsert.length -


### PR DESCRIPTION
There is a small typo in tests/qunit/qunit.js.

Should read `suffixes` rather than `suffixies`.

